### PR TITLE
Repaired misunderstanding about usage of STDERR. Script's main payloa…

### DIFF
--- a/QoE-REST-RatePlansManagement.py
+++ b/QoE-REST-RatePlansManagement.py
@@ -51,8 +51,8 @@ URL_PREFIX = "https://" + QoE_MNG_IP + ":" + QoE_REST_PORT + REST_API_END_POINT
 ######################################################################
 
 def print_stderr(*args, **kwargs):
-#    print(*args, file=sys.stderr, **kwargs)
-    print(*args, **kwargs)
+    print(*args, file=sys.stderr, **kwargs)
+#    print(*args, **kwargs)
 
 
 def print_qoe_access_info():
@@ -110,7 +110,7 @@ def read_qoe_rest_access_info(configFileName):
 def processResponse(response, print_resp=1):
     if(print_resp == 1):
         if("Content-Length" in response.headers and int(response.headers["Content-Length"]) > 0):
-            print_stderr(json.dumps(response.json(), indent=4))
+            print(json.dumps(response.json(), indent=4))
     return response.status_code
 
 


### PR DESCRIPTION
Repaired misunderstanding about usage of STDERR.

Script's main payload JSON output should be sent to STDOUT.

Any human-readable information such as debug information, reports explaining what the script is doing at a specific moment in time, error reports, and usage/help spiels should be printed to STDERR.

As a result of handling output this way, a command like:
`python ./QoE-REST-RatePlansManagement.py $ARGUMENTS | another_script_that_expects_raw_json.py`

will feed the desired json output into the next script,
while all other human-intended output still gets printed to the terminal and never reaches the second script.
